### PR TITLE
Do not display a notice when using CommandClass methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,5 +59,10 @@ module.exports = {
 			'LabeledStatement',
 			'WithStatement',
 		],
+		'new-cap': [2, {
+			newIsCap: true,
+			// Do not display a notice when using CommandClass methods
+			{ "newIsCapExceptionPattern": "^node.CommandClass\.." },
+		}],
 	},
 };


### PR DESCRIPTION
Using the example of the athom documentation:

```javascript
node.CommandClass.COMMAND_CLASS_BASIC.BASIC_SET({
    Value: true
}, function( err, result ){
    if( err ) return console.error( err );
});
```

results in:

```error| A function with a name starting with an uppercase letter should only be used as a constructor. (new-cap)```